### PR TITLE
Ver contador de partidos creados y jugadores anotados en las últimas dos horas

### DIFF
--- a/backend/src/main/java/matches/organizer/controller/MatchController.java
+++ b/backend/src/main/java/matches/organizer/controller/MatchController.java
@@ -1,27 +1,22 @@
 package matches.organizer.controller;
 
-import matches.organizer.domain.Match;
+import matches.organizer.dto.CounterDTO;
 import matches.organizer.dto.MatchDTO;
 import matches.organizer.service.MatchService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
-import java.util.ArrayList;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @RestController
 @EnableWebMvc
 public class MatchController {
-
     private final MatchService matchService;
 
     @Autowired
@@ -32,5 +27,14 @@ public class MatchController {
     @GetMapping(value = "/matches", produces = MediaType.APPLICATION_JSON_VALUE)
     public @ResponseBody List<MatchDTO> getAllMatches() {
         return matchService.getMatches().stream().map(match -> match.getDto()).collect(Collectors.toList());
+    }
+
+    /**
+     * Retorna un contador con la cantidad de partidos creados y jugadores anotados en las últimas 2 horas.
+     */
+    @GetMapping(value = "/matches/counter", produces = MediaType.APPLICATION_JSON_VALUE)
+    public @ResponseBody CounterDTO getMatchAndPlayerCounter() {
+        LocalDateTime from = LocalDateTime.now().minusHours(2);
+        return matchService.getMatchAndPlayerCounterFrom(from);
     }
 }

--- a/backend/src/main/java/matches/organizer/controller/MatchController.java
+++ b/backend/src/main/java/matches/organizer/controller/MatchController.java
@@ -1,5 +1,6 @@
 package matches.organizer.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import matches.organizer.dto.CounterDTO;
 import matches.organizer.dto.MatchDTO;
 import matches.organizer.service.MatchService;
@@ -29,9 +30,7 @@ public class MatchController {
         return matchService.getMatches().stream().map(match -> match.getDto()).collect(Collectors.toList());
     }
 
-    /**
-     * Retorna un contador con la cantidad de partidos creados y jugadores anotados en las últimas 2 horas.
-     */
+    @Operation(summary = "Retorna un contador con la cantidad de partidos creados y jugadores anotados en las últimas 2 horas.")
     @GetMapping(value = "/matches/counter", produces = MediaType.APPLICATION_JSON_VALUE)
     public @ResponseBody CounterDTO getMatchAndPlayerCounter() {
         LocalDateTime from = LocalDateTime.now().minusHours(2);

--- a/backend/src/main/java/matches/organizer/domain/Match.java
+++ b/backend/src/main/java/matches/organizer/domain/Match.java
@@ -19,17 +19,17 @@ public class Match {
     private LocalDate date;
     private LocalTime hour;
     private String location;
-    private LocalDateTime creationDate;
+    private LocalDateTime createdAt;
     private List<Player> players;
 
-    public Match(UUID id, String name, UUID userId, LocalDate date, LocalTime hour, String location, LocalDateTime creationDate){
+    public Match(UUID id, String name, UUID userId, LocalDate date, LocalTime hour, String location, LocalDateTime createdAt){
        this.id = id;
        this.name = name;
        this.userId = userId;
        this.date = date;
        this.hour = hour;
        this.location = location;
-       this.creationDate = creationDate;
+       this.createdAt = createdAt;
        this.players = new ArrayList<>();
     }
 
@@ -53,12 +53,17 @@ public class Match {
         return hour;
     }
 
+    public LocalDateTime getDateTime() { return hour.atDate(date);}
+
     public String getLocation() {
         return location;
     }
 
-    public LocalDateTime getCreationDate() {
-        return creationDate;
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+    public void setCreatedAt(LocalDateTime dateTime) {
+        this.createdAt = dateTime;
     }
 
     public List<Player> getPlayers() { return players; }

--- a/backend/src/main/java/matches/organizer/domain/MatchBuilder.java
+++ b/backend/src/main/java/matches/organizer/domain/MatchBuilder.java
@@ -54,8 +54,8 @@ public class MatchBuilder {
         if(!LocalDateTime.now().isBefore(LocalDateTime.of(date, hour)))
             throw new MatchBuildException("MatchBuilder: date and hour is in the past");
         UUID id = UUID.randomUUID();
-        LocalDateTime creationDate = LocalDateTime.now();
+        LocalDateTime createdAt = LocalDateTime.now();
 
-        return new Match(id, name, userId, date, hour, location, creationDate);
+        return new Match(id, name, userId, date, hour, location, createdAt);
     }
 }

--- a/backend/src/main/java/matches/organizer/domain/Player.java
+++ b/backend/src/main/java/matches/organizer/domain/Player.java
@@ -7,18 +7,26 @@ import java.util.UUID;
 
 public class Player {
 
-    private UUID userId;
+    private final UUID userId;
 
-    private LocalDateTime confirmationDate;
+    private LocalDateTime confirmedAt;
 
     public Player(UUID userId) {
         this.userId = userId;
-        this.confirmationDate = LocalDateTime.now();
+        this.confirmedAt = LocalDateTime.now();
     }
 
-    public UUID getUserId() { return userId; }
+    public UUID getUserId() {
+        return userId;
+    }
 
-    public LocalDateTime getConfirmationDate() { return confirmationDate; }
+    public LocalDateTime getConfirmedAt() {
+        return confirmedAt;
+    }
+
+    public void setConfirmedAt(LocalDateTime confirmedAt) {
+        this.confirmedAt = confirmedAt;
+    }
 
     public PlayerDTO getDto() {
         return new PlayerDTO(this);

--- a/backend/src/main/java/matches/organizer/dto/CounterDTO.java
+++ b/backend/src/main/java/matches/organizer/dto/CounterDTO.java
@@ -1,0 +1,21 @@
+package matches.organizer.dto;
+
+import matches.organizer.domain.Player;
+
+public class CounterDTO {
+    private int matches;
+    private int players;
+
+    public CounterDTO(int matches, int players) {
+        this.matches = matches;
+        this.players = players;
+    }
+
+    public int getPlayers() {
+        return players;
+    }
+
+    public int getMatches() {
+        return matches;
+    }
+}

--- a/backend/src/main/java/matches/organizer/dto/MatchDTO.java
+++ b/backend/src/main/java/matches/organizer/dto/MatchDTO.java
@@ -18,7 +18,7 @@ public class MatchDTO {
     private LocalDate date;
     private LocalTime hour;
     private String location;
-    private LocalDateTime creationDate;
+    private LocalDateTime createdAt;
     private List<PlayerDTO> startingPlayers;
     private List<PlayerDTO> substitutePlayers;
 
@@ -29,7 +29,7 @@ public class MatchDTO {
         this.date = match.getDate();
         this.hour = match.getHour();
         this.location = match.getLocation();
-        this.creationDate = match.getCreationDate();
+        this.createdAt = match.getCreatedAt();
         this.startingPlayers = match.getStartingPlayers().stream().map(Player::getDto).collect(Collectors.toList());
         this.substitutePlayers = match.getSubstitutePlayers().stream().map(Player::getDto).collect(Collectors.toList());
     }
@@ -58,8 +58,8 @@ public class MatchDTO {
         return location;
     }
 
-    public String getCreationDate() {
-        return creationDate.toString();
+    public String getCreatedAt() {
+        return createdAt.toString();
     }
 
     public List<PlayerDTO> getStartingPlayers() {

--- a/backend/src/main/java/matches/organizer/dto/PlayerDTO.java
+++ b/backend/src/main/java/matches/organizer/dto/PlayerDTO.java
@@ -7,13 +7,13 @@ import java.util.UUID;
 
 public class PlayerDTO {
     private UUID userId;
-    private LocalDateTime confirmationDate;
+    private LocalDateTime confirmedAt;
 
     public PlayerDTO(Player player) {
         this.userId = player.getUserId();
-        this.confirmationDate = player.getConfirmationDate();
+        this.confirmedAt = player.getConfirmedAt();
     }
 
     public UUID getUserId() { return userId; }
-    public String getConfirmationDate() { return confirmationDate.toString(); }
+    public String getConfirmedAt() { return confirmedAt.toString(); }
 }

--- a/backend/src/main/java/matches/organizer/service/MatchService.java
+++ b/backend/src/main/java/matches/organizer/service/MatchService.java
@@ -4,6 +4,7 @@ import matches.organizer.domain.Match;
 import matches.organizer.domain.MatchBuilder;
 import matches.organizer.domain.Player;
 import matches.organizer.domain.User;
+import matches.organizer.dto.CounterDTO;
 import matches.organizer.storage.MatchRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -11,7 +12,6 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -19,10 +19,12 @@ import java.util.UUID;
 public class MatchService {
 
     private final MatchRepository matchRepository;
+
     @Autowired
     public MatchService(MatchRepository matchRepository) {
         this.matchRepository = matchRepository;
     }
+
     public List<Match> getMatches() {
         User anyUser = new User("Arthur", "Arthur Friedenreich", "Mi contraseña secreta");
         Match anyMatch = new MatchBuilder()
@@ -32,8 +34,22 @@ public class MatchService {
                 .setHour(LocalTime.now())
                 .setLocation("La Bombonera")
                 .build();
+
         anyMatch.addPlayer(anyUser, "1234-5678", "afriedenreich@gmail.com");
         matchRepository.add(anyMatch);
         return matchRepository.getAll();
+    }
+
+    /**
+     * Retorna un contador con la cantidad de partidos creados y jugadores anotados a partir de una fecha/hora.
+     *
+     * @param from DateTime a partir del cual se buscaran los partidos y jugadores
+     * @see CounterDTO
+     */
+    public CounterDTO getMatchAndPlayerCounterFrom(LocalDateTime from) {
+        List<Match> matches = matchRepository.getAllCreatedFrom(from);
+        List<Player> players = matchRepository.getAllPlayersConfirmedFrom(from);
+
+        return new CounterDTO(matches.size(), players.size());
     }
 }

--- a/backend/src/main/java/matches/organizer/storage/InMemoryMatchRepository.java
+++ b/backend/src/main/java/matches/organizer/storage/InMemoryMatchRepository.java
@@ -1,22 +1,30 @@
 package matches.organizer.storage;
 
 import matches.organizer.domain.Match;
+import matches.organizer.domain.Player;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Component
 public class InMemoryMatchRepository implements MatchRepository {
 
     private final List<Match> matches = new ArrayList<>();
 
+    private static boolean hasSameId(UUID anyMatchId, Match match) {
+        return anyMatchId.toString().equals(match.getId().toString());
+    }
+
     @Override
     public Match get(UUID id) {
         return matches.stream()
                 .filter(match -> hasSameId(id, match))
-                .findFirst().orElse(null);
+                .findFirst()
+                .orElse(null);
     }
 
     @Override
@@ -41,7 +49,18 @@ public class InMemoryMatchRepository implements MatchRepository {
         matches.removeIf(anyMatch -> hasSameId(anyMatch.getId(), match));
     }
 
-    private static boolean hasSameId(UUID anyMatchId, Match match) {
-        return anyMatchId.toString().equals(match.getId().toString());
+    @Override
+    public List<Match> getAllCreatedFrom(LocalDateTime from) {
+        return matches.stream()
+                .filter(match -> match.getCreatedAt().isAfter(from))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Player> getAllPlayersConfirmedFrom(LocalDateTime from) {
+        return matches.stream()
+                .flatMap(match -> match.getPlayers().stream())
+                .filter(player -> player.getConfirmedAt().isAfter(from))
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/matches/organizer/storage/MatchRepository.java
+++ b/backend/src/main/java/matches/organizer/storage/MatchRepository.java
@@ -1,7 +1,9 @@
 package matches.organizer.storage;
 
 import matches.organizer.domain.Match;
+import matches.organizer.domain.Player;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -11,4 +13,6 @@ public interface MatchRepository {
     void add(Match match);
     void update(Match match);
     void remove(Match match);
+    List<Match> getAllCreatedFrom(LocalDateTime from);
+    List<Player> getAllPlayersConfirmedFrom(LocalDateTime from);
 }

--- a/backend/src/test/java/matches/organizer/controller/MatchControllerTest.java
+++ b/backend/src/test/java/matches/organizer/controller/MatchControllerTest.java
@@ -1,28 +1,100 @@
 package matches.organizer.controller;
 
+import matches.organizer.domain.Match;
+import matches.organizer.domain.MatchBuilder;
+import matches.organizer.domain.User;
 import matches.organizer.service.MatchService;
 import matches.organizer.storage.InMemoryMatchRepository;
+import matches.organizer.storage.MatchRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.ResultActions;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest(classes={MatchService.class,MatchController.class, InMemoryMatchRepository.class})
+@SpringBootTest(classes = {MatchService.class, MatchController.class, InMemoryMatchRepository.class})
 @AutoConfigureMockMvc
 class MatchControllerTest {
 
-	@Autowired
-	private MockMvc mvc;
+    @Autowired
+    private MockMvc mvc;
+    @Autowired
+    private MatchRepository matchRepository;
 
-	@Test
-	void matchesRetrieved() throws Exception {
-		this.mvc.perform(MockMvcRequestBuilders.get("/matches").accept(MediaType.APPLICATION_JSON_VALUE))
-				.andExpect(status().isOk());
-	}
 
+    @Test
+    void matchesRetrieved() throws Exception {
+        this.mvc.perform(get("/matches").accept(MediaType.APPLICATION_JSON_VALUE)).andExpect(status().isOk());
+    }
+
+    /**
+     * Verifica: Obtencion de contador con la cantidad de partidos creados y jugadores anotados en las últimas 2 horas.
+     */
+    @Test
+    void matchesCounterRetrieved() throws Exception {
+        ResultActions result;
+
+        ///////							Test Empty Counter					///////
+        ///////////////////////////////////////////////////////////////////////////
+        sanitize();
+
+        result = this.mvc.perform(get("/matches/counter").accept(MediaType.APPLICATION_JSON_VALUE));
+        result = result.andExpect(status().isOk());
+        result = result.andExpect(content().json("{'matches': 0, 'players': 0}"));
+
+
+        ///////							Test Counter						///////
+        ///////////////////////////////////////////////////////////////////////////
+
+        // Valid matches: 1, Valid Players: 2
+        Match m1 = createMatch();
+        m1.addPlayer(createUser(), "", "");
+        m1.addPlayer(createUser(), "", "");
+
+        // Invalid matches and players (older than 2 hours)
+        LocalDateTime oderDT = LocalDateTime.now().minusHours(2).minusMinutes(1);
+
+        Match m2 = createMatch();
+        m2.setCreatedAt(oderDT);
+
+        m1.addPlayer(createUser(), "", "");
+        m1.getPlayers().get(0).setConfirmedAt(oderDT);
+
+        // Test
+        matchRepository.add(m1);
+        matchRepository.add(m2);
+
+        result = this.mvc.perform(get("/matches/counter").accept(MediaType.APPLICATION_JSON_VALUE));
+        result = result.andExpect(status().isOk());
+        result = result.andExpect(content().json("{'matches': 1, 'players': 2}"));
+    }
+
+    void sanitize() {
+        matchRepository.getAll().clear();
+    }
+
+    Match createMatch() {
+        return new MatchBuilder().
+                setName("Match").
+                setLocation("Location").
+                setUserId(UUID.randomUUID()).
+                setDate(LocalDate.now().plusDays(1))
+                .setHour(LocalTime.now())
+                .build();
+    }
+
+    User createUser() {
+        return new User("User", "User", "Password");
+    }
 }


### PR DESCRIPTION
**Incluye:**

- Controller + Domain
- Testing
- Documentacion

**Captura con diseno REST**:

Nota: Se opto por no agregar query params con filtros personalizados, ya que el unico filtro es que la creacion sea de 2 horas (Esto esta indicado en la doc del swagger). En caso de que se necesiten crear mas filtros en un futuro se pueden agregar query params para este fin.

![Screenshot from 2022-09-04 15-00-17](https://user-images.githubusercontent.com/43507646/188327201-6c9cdb8f-4e38-443a-8837-84776b0a2870.png)
