### PR TITLE
Se agrega un improve para que los matches no conozcan a los usuarios.

### DIFF
--- a/backend/src/main/java/matches/organizer/domain/Match.java
+++ b/backend/src/main/java/matches/organizer/domain/Match.java
@@ -1,7 +1,6 @@
 package matches.organizer.domain;
 
 import matches.organizer.dto.MatchDTO;
-import matches.organizer.exception.AddPlayerException;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -80,16 +79,8 @@ public class Match {
         players = new ArrayList<>();
     }
 
-    public void addPlayer(User user, String phone, String email) {
-        if(players.size() >= 13)
-            throw new AddPlayerException("Match: Cannot add player. The team is complete.");
-        if(phone == null)
-            throw new AddPlayerException("Match: Cannot add player. Phone cannot be null.");
-        if(email == null)
-            throw new AddPlayerException("Match: Cannot add player. Email cannot be null.");
-        user.setPhone(phone);
-        user.setEmail(email);
-        players.add(new Player(user.getId()));
+    public void addPlayer(UUID userId) {
+        players.add(new Player(userId));
     }
 
     public MatchDTO getDto() {

--- a/backend/src/main/java/matches/organizer/service/MatchService.java
+++ b/backend/src/main/java/matches/organizer/service/MatchService.java
@@ -5,7 +5,9 @@ import matches.organizer.domain.MatchBuilder;
 import matches.organizer.domain.Player;
 import matches.organizer.domain.User;
 import matches.organizer.dto.CounterDTO;
+import matches.organizer.exception.AddPlayerException;
 import matches.organizer.storage.MatchRepository;
+import matches.organizer.storage.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -19,10 +21,12 @@ import java.util.UUID;
 public class MatchService {
 
     private final MatchRepository matchRepository;
+    private final UserRepository userRepository;
 
     @Autowired
-    public MatchService(MatchRepository matchRepository) {
+    public MatchService(MatchRepository matchRepository, UserRepository userRepository) {
         this.matchRepository = matchRepository;
+        this.userRepository = userRepository;
     }
 
     public List<Match> getMatches() {
@@ -34,8 +38,7 @@ public class MatchService {
                 .setHour(LocalTime.now())
                 .setLocation("La Bombonera")
                 .build();
-
-        anyMatch.addPlayer(anyUser, "1234-5678", "afriedenreich@gmail.com");
+        addPlayerToMatch(anyMatch, anyUser, "1234-5678", "afriedenreich@gmail.com");
         matchRepository.add(anyMatch);
         return matchRepository.getAll();
     }
@@ -51,5 +54,22 @@ public class MatchService {
         List<Player> players = matchRepository.getAllPlayersConfirmedFrom(from);
 
         return new CounterDTO(matches.size(), players.size());
+    }
+
+    public void addPlayerToMatch(Match match, User user, String phone, String email) {
+        if(match.getPlayers().size() >= 13)
+            throw new AddPlayerException("Match: Cannot add player. The team is complete.");
+        if(phone == null)
+            throw new AddPlayerException("Match: Cannot add player. Phone cannot be null.");
+        if(email == null)
+            throw new AddPlayerException("Match: Cannot add player. Email cannot be null.");
+        user.setPhone(phone);
+        user.setEmail(email);
+        if (userRepository.get(user.getId()) != null) {
+            userRepository.update(user);
+        } else {
+            userRepository.add(user);
+        }
+        match.addPlayer(user.getId());
     }
 }

--- a/backend/src/test/java/matches/organizer/storage/InMemoryMatchRepositoryTest.java
+++ b/backend/src/test/java/matches/organizer/storage/InMemoryMatchRepositoryTest.java
@@ -2,7 +2,6 @@ package matches.organizer.storage;
 
 import matches.organizer.domain.Match;
 import matches.organizer.domain.MatchBuilder;
-import matches.organizer.domain.User;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,12 +20,6 @@ class InMemoryMatchRepositoryTest {
     private MatchRepository matchRepository;
     private Match anyMatch;
     private Match anotherMatch;
-    private final User user1 = new User("1", "User 1", "1111");
-    private final User user2 = new User("2", "User 2", "2222");
-    private final User user3 = new User("3", "User 3", "3333");
-    private final User user4 = new User("4", "User 4", "4444");
-    private final User user5 = new User("5", "User 5", "5555");
-
 
     @BeforeEach
     void setUp() {
@@ -86,9 +79,9 @@ class InMemoryMatchRepositoryTest {
                 .setHour(LocalTime.now())
                 .setLocation("La Bombonera")
                 .build();
-        anyMatch.addPlayer(user1, "1111-1111", "player1@gmail.com");
-        anyMatch.addPlayer(user2, "2222-2222", "player2@gmail.com");
-        anyMatch.addPlayer(user3, "3333-3333", "player3@gmail.com");
+        anyMatch.addPlayer(UUID.randomUUID());
+        anyMatch.addPlayer(UUID.randomUUID());
+        anyMatch.addPlayer(UUID.randomUUID());
         return anyMatch;
     }
 
@@ -100,8 +93,8 @@ class InMemoryMatchRepositoryTest {
                 .setHour(LocalTime.now())
                 .setLocation("La Bombonera")
                 .build();
-        anotherMatch.addPlayer(user4, "4444-4444", "player4@gmail.com");
-        anotherMatch.addPlayer(user5, "5555-5555", "player5@gmail.com");
+        anotherMatch.addPlayer(UUID.randomUUID());
+        anotherMatch.addPlayer(UUID.randomUUID());
         return anotherMatch;
     }
 }


### PR DESCRIPTION
Salvo por sus id.
Esto me parece que desacopla un poco al match del manejo de usuarios, que debería ser responsabilidad del service, ya que este debe interactuar con el repository de usuarios y validar "el negocio".
Si miran los tests, se ve que para crear un match tenías que armar usuarios, y el match sólo tiene el id de este