### PR TITLE
68 be implementar load test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,13 @@ prod: ## Levanta componentes del proyecto, buildea en caso de no encontrar la im
 .PHONY: stop
 stop: ## Finaliza la ejecución de los componentes del proyecto
 	docker-compose down
+
+.PHONY: lt-matches
+lt-matches: ## lt-matches token=<jwt-token>. Test de Carga HTTP del endpoint GET '/matches'.
+	@if [ -z $(token) ];\
+	then \
+		echo "¡Token no proporcionado!\n   Uso: make lt-matches token=<jwt-token>" ;\
+	else \
+		docker run --network=host --rm -i peterevans/vegeta sh -c \
+		"echo 'GET http://localhost:8081/matches' | vegeta attack -header 'Cookie: token=$(token)' -duration=1s | tee results.bin | vegeta report" ; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,11 @@ clean: ## Elimina los containers e imagenes (no borra la cache)
 	docker container rm be-organize-matches fe-organize-matches; \
 	docker image rm --no-prune be-organize-matches fe-organize-matches;
 
+.PHONY: lt-counter
+lt-counter: ## Test de Carga HTTP del endpoint /matches/counter
+	docker run --network=host --rm -i peterevans/vegeta sh -c \
+	"echo 'GET http://localhost:8081/matches/counter' | vegeta attack -duration=1s | tee results.bin | vegeta report"
+
 .PHONY: prod
 prod: ## Levanta componentes del proyecto, buildea en caso de no encontrar la imagen correspondiente.
 	docker-compose up -d;

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BE_DOCKER_TAG = be-organize-matches:latest
 FE_DOCKER_TAG = fe-organize-matches:latest
-VEGETA_DURATION = 10s
+VEGETA_DURATION = 5s
 VEGETA_RATE = 0
 VEGETA_MAX_WORKERS = 1000
 
@@ -58,14 +58,13 @@ lt-new-match: ## lt-new-match token=<jwt-token>. Test de Carga HTTP del endpoint
 	then \
 		echo "¡Token no proporcionado!\n   Uso: make lt-new-match token=<jwt-token>" ;\
 	else \
-		docker run --network=host --rm -i peterevans/vegeta \
-		printf "POST http://localhost:8081/matches\n@./body.json" > target.txt && \
-		echo "{ \"name\": \"test\", \"location\": \"test\", \"dateAndTime\": \"2099-01-01T00:00:00.000Z\" }" > body.json && \
-		sh -c \
-		"vegeta attack -targets=target.txt \
+		docker run --network=host --rm -i peterevans/vegeta sh -c\
+		"printf 'POST http://localhost:8081/matches\n@./body.json' > target.txt && \
+		echo '{ \"name\": \"test\", \"location\": \"test\", \"dateAndTime\": \"2099-01-01T00:00:00.000Z\" }' > body.json && \
+		vegeta attack -targets=target.txt \
 		-header 'Cookie: token=$(token)' \
 		-header 'Content-Type: application/json' \
 		-format=http -duration=$(VEGETA_DURATION) -rate=$(VEGETA_RATE) -max-workers=$(VEGETA_MAX_WORKERS) \
-		| tee results.bin | vegeta report" \
-		&& rm body.json && rm target.txt && rm results.bin ;\
+		| tee results.bin | vegeta report \
+		&& rm body.json && rm target.txt && rm results.bin ";\
 	fi

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 BE_DOCKER_TAG = be-organize-matches:latest
 FE_DOCKER_TAG = fe-organize-matches:latest
-
+VEGETA_DURATION = 10s
+VEGETA_RATE = 0
+VEGETA_MAX_WORKERS = 1000
 
 PHONY: help
 help: ## Imprime targets y ayuda 
@@ -38,7 +40,7 @@ stop: ## Finaliza la ejecución de los componentes del proyecto
 .PHONY: lt-counter
 lt-counter: ## Test de Carga HTTP del endpoint GET '/matches/counter'
 	docker run --network=host --rm -i peterevans/vegeta sh -c \
-	"echo 'GET http://localhost:8081/matches/counter' | vegeta attack -duration=1s | tee results.bin | vegeta report"
+	"echo 'GET http://localhost:8081/matches/counter' | vegeta attack -duration=$(VEGETA_DURATION) -rate=$(VEGETA_RATE) -max-workers=$(VEGETA_MAX_WORKERS) | tee results.bin | vegeta report"
 
 .PHONY: lt-matches
 lt-matches: ## lt-matches token=<jwt-token>. Test de Carga HTTP del endpoint GET '/matches'.
@@ -47,7 +49,7 @@ lt-matches: ## lt-matches token=<jwt-token>. Test de Carga HTTP del endpoint GET
 		echo "¡Token no proporcionado!\n   Uso: make lt-matches token=<jwt-token>" ;\
 	else \
 		docker run --network=host --rm -i peterevans/vegeta sh -c \
-		"echo 'GET http://localhost:8081/matches' | vegeta attack -header 'Cookie: token=$(token)' -duration=1s | tee results.bin | vegeta report" ; \
+		"echo 'GET http://localhost:8081/matches' | vegeta attack -header 'Cookie: token=$(token)' -duration=$(VEGETA_DURATION) -rate=$(VEGETA_RATE) -max-workers=$(VEGETA_MAX_WORKERS) | tee results.bin | vegeta report" ; \
 	fi
 
 .PHONY: lt-new-match
@@ -63,7 +65,7 @@ lt-new-match: ## lt-new-match token=<jwt-token>. Test de Carga HTTP del endpoint
 		"vegeta attack -targets=target.txt \
 		-header 'Cookie: token=$(token)' \
 		-header 'Content-Type: application/json' \
-		-format=http -duration=1s \
+		-format=http -duration=$(VEGETA_DURATION) -rate=$(VEGETA_RATE) -max-workers=$(VEGETA_MAX_WORKERS) \
 		| tee results.bin | vegeta report" \
 		&& rm body.json && rm target.txt && rm results.bin ;\
 	fi

--- a/README.md
+++ b/README.md
@@ -77,3 +77,11 @@ Para ver los test de carga HTTP disponibles, ejecutar el siguiente comando:
 ```shell
 make help | grep lt
 ```
+
+Para modificar parametros de los tests de carga, modificar las siguientes variables en el Makefile:
+
+```
+VEGETA_DURATION = 10s # Cantidad de segundos del test
+VEGETA_RATE = 0 # Maxima cantidad de request por segundo. (0 es infinito)
+VEGETA_MAX_WORKERS = 1000 # Maxima cantidad de usuarios (Nota: 1 usuario puede hacer N request)
+```

--- a/README.md
+++ b/README.md
@@ -69,3 +69,11 @@ un archivo llamado `mongo-pass.txt` con la password del usuario `root` de la bas
 
 ### Mongo-Express
 http://localhost:8082/
+
+## Testing
+
+Para ver los test de carga HTTP disponibles, ejecutar el siguiente comando:
+
+```shell
+make help | grep lt
+```


### PR DESCRIPTION
### Resumen

Incluye 3 loading tests utilizando la tool Vegeta dockerizada, invocada via Makefile. (Issue relacionado https://github.com/leobz/organize-matches/issues/68)

### Uso

Para ver los test de carga HTTP disponibles, ejecutar el siguiente comando:

```
$ make help | grep lt

lt-counter                     Test de Carga HTTP del endpoint /matches/counter
lt-matches                     lt-matches token=<jwt-token>. Test de Carga HTTP del endpoint GET '/matches'.
lt-new-match                   lt-new-match token=<jwt-token>. Test de Carga HTTP del endpoint POST '/matches'.
```

Para modificar parametros de los tests de carga, modificar las siguientes variables en el Makefile:

```
VEGETA_DURATION = 10s # Cantidad de segundos del test
VEGETA_RATE = 0 # Maxima cantidad de request por segundo. (0 es infinito)
VEGETA_MAX_WORKERS = 1000 # Maxima cantidad de usuarios (Nota: 1 usuario puede hacer N request)
```

### Pruebas

Match Counter
![image](https://user-images.githubusercontent.com/43507646/194713606-422a3463-9bc9-4375-9697-b85b87db1463.png)


List matches sin token
![image](https://user-images.githubusercontent.com/43507646/194713647-1da34e50-f7e3-4fc1-b75c-9ee60381af09.png)


List match
![image](https://user-images.githubusercontent.com/43507646/194713689-5035a20b-45ce-4720-b89b-09b4c9820f7e.png)


Nuevo match
![image](https://user-images.githubusercontent.com/43507646/194713672-45c5ea82-dd34-4e7f-b5cf-d74cb266f595.png)
