### PR TITLE
Se aplican entornos distintos para dev y prod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,6 @@ node_modules/
 
 out/
 
+mongo/**
+
 mongo-pass.txt

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,21 @@ VEGETA_DURATION = 5s
 VEGETA_RATE = 0
 VEGETA_MAX_WORKERS = 1000
 
+
+## Retrocompatibilidad con versiones de docker compose.
+## More info: https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command
+define DOCKER_COMPOSE
+	@if which docker-compose  >/dev/null ; then docker-compose  $1; fi;
+    @if which docker compose  >/dev/null ; then docker compose $1; fi;
+endef
+
 PHONY: help
 help: ## Imprime targets y ayuda 
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: dev
 dev: ## Compila y ejecuta localmente el backend
-	docker-compose up -d;
+	$(call DOCKER_COMPOSE, up -d)
 
 .PHONY: build
 build: ## Crea imagen docker del todos los componentes (backend y frontend)
@@ -27,11 +35,12 @@ clean: ## Elimina los containers e imagenes (no borra la cache)
 
 .PHONY: prod
 prod: ## Levanta componentes del proyecto, buildea en caso de no encontrar la imagen correspondiente.
-	docker-compose -f docker-compose.yml -f production.yml up -d;
+	$(call DOCKER_COMPOSE, -f docker-compose.yml -f production.yml up -d)
+
 
 .PHONY: stop
 stop: ## Finaliza la ejecución de los componentes del proyecto
-	docker-compose down
+	$(call DOCKER_COMPOSE, down)
 
 .PHONY: lt-counter
 lt-counter: ## Test de Carga HTTP del endpoint GET '/matches/counter'

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,7 @@ help: ## Imprime targets y ayuda
 
 .PHONY: dev
 dev: ## Compila y ejecuta localmente el backend
-	cd backend; \
-	mvn clean install; \
-	docker-compose up -d mongo; \
-	java -jar target/matches-organizer-0.0.1-SNAPSHOT.jar \
-	--spring.data.mongodb.uri=mongodb://root:$(shell cat mongo-pass.txt)@localhost:27017/admin?authMechanism=SCRAM-SHA-256
+	docker-compose up -d;
 
 .PHONY: build
 build: ## Crea imagen docker del todos los componentes (backend y frontend)
@@ -31,7 +27,7 @@ clean: ## Elimina los containers e imagenes (no borra la cache)
 
 .PHONY: prod
 prod: ## Levanta componentes del proyecto, buildea en caso de no encontrar la imagen correspondiente.
-	docker-compose up -d;
+	docker-compose -f docker-compose.yml -f production.yml up -d;
 
 .PHONY: stop
 stop: ## Finaliza la ejecución de los componentes del proyecto

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -32,4 +32,4 @@ WORKDIR /opt
 # - https://www.javadevjournal.com/java/jvm-parameters/
 CMD ["-Xmx1000m", "-Xms512m", "-XX:+HeapDUmpOnOutOfMemoryError", "-XX:HeapDumpPath=/opt/logs"]
 
-ENTRYPOINT java -jar ./app.jar --spring.data.mongodb.uri=mongodb://root:$(cat /run/secrets/mongo-pass)@mongo:27017/admin?authMechanism=SCRAM-SHA-256
+ENTRYPOINT java -jar ./app.jar --spring.profiles.active=$ENV --spring.data.mongodb.uri=mongodb://root:$(cat /run/secrets/mongo-pass)@mongo:27017/admin?authMechanism=SCRAM-SHA-256

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -8,3 +8,21 @@ spring:
 
 server:
   port: 8081
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+  data:
+    mongodb:
+      database: organize-matches-dev
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+  data:
+    mongodb:
+      database: organize-matches

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,3 +1,4 @@
+spring.profiles.active=test
 spring.mongodb.embedded.version=4.0.21
 logging.level.org.springframework.boot.autoconfigure.mongo.embedded=off
 logging.level.org.mongodb=off

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,10 @@ services:
     image: be-organize-matches:latest
     container_name: be-organize-matches
     restart: on-failure
+    environment:
+      ENV: dev
     depends_on:
-      - "mongo"
+      - mongo
     ports:
       - "8081:8081"
     secrets:
@@ -42,7 +44,7 @@ services:
     ports:
       - "8082:8081"
     depends_on:
-      - "mongo"
+      - mongo
     environment:
       ME_CONFIG_MONGODB_ADMINUSERNAME: root
       ME_CONFIG_MONGODB_ADMINPASSWORD_FILE: /run/secrets/mongo-pass

--- a/production.yml
+++ b/production.yml
@@ -1,0 +1,9 @@
+version: "3.9"
+services: 
+  backend:
+    build: ./backend
+    environment:
+      ENV: prod
+  mongo:
+    volumes:
+      - ./mongo:/data/db


### PR DESCRIPTION
Para `test`:
- Levanta el mongo embebido

Para `dev`:
- La base de mongo se llama `organize-matches-dev`
- El volumen es el generado por docker mongo
- Ya no se levanta sólo el backend, se levanta con el front también

Para `prod`:
- La base de mongo se llama `organize-matches`
- El volumen se guarda en el directorio `/mongo` del repo

Nota: No pude desenganchar la contraseña del mongo de prod, del de dev debido a que se la paso con un string fijo en el Dockerfile. Cuando tengamos una base en el cloud lo vamos a tener que cambiar de todos modos