### PR TITLE
Se mockea repositorio de matches en test del controller

### DIFF
--- a/backend/src/main/java/matches/organizer/controller/MatchController.java
+++ b/backend/src/main/java/matches/organizer/controller/MatchController.java
@@ -72,9 +72,9 @@ public class MatchController {
         Match match = matchService.getMatch(matchId);
         String tokenUserId = jwtUtils.getUserFromToken(auth);
         logger.info("Match id " + matchId);
-        logger.info("New Match id " + newMatch.getId().toString());
+        logger.info("New Match id " + newMatch.getId());
         logger.info("Token user id" + tokenUserId);
-        logger.info("Match user id" + match.getUserId().toString());
+        logger.info("Match user id" + match.getUserId());
         logger.info("Date time: " + match.getDateAndTime());
         logger.info("New Date time: " + newMatch.getDateAndTime());
         if(match.getUserId().compareTo(tokenUserId) != 0) {

--- a/backend/src/main/java/matches/organizer/service/MatchService.java
+++ b/backend/src/main/java/matches/organizer/service/MatchService.java
@@ -112,11 +112,6 @@ public class MatchService {
                 .build();
     }
 
-    public void createAndSaveRandomMatch() {
-        Match match = createRandomMatch();
-        matchRepository.save(match);
-    }
-
     public void registerNewPlayer(String id, User user) {
         Match match = matchRepository.findById(id).orElse(null);
         logger.error("LEST TRY WITH: {} , {}", user.getId(), match.getId());
@@ -146,7 +141,7 @@ public class MatchService {
             logger.info("PLAYER WITH ID: " + playerId + " REMOVED CORRECTLY FROM MATCH " + match.getId());
             return match.getPlayers();
         } else {
-            logger.error("MATCH NOT FOUND WITH ID: " + matchId.toString());
+            logger.error("MATCH NOT FOUND WITH ID: " + matchId);
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Match not found.");
         }
     }

--- a/backend/src/test/java/matches/organizer/controller/MatchControllerTest.java
+++ b/backend/src/test/java/matches/organizer/controller/MatchControllerTest.java
@@ -8,6 +8,7 @@ import matches.organizer.domain.User;
 import matches.organizer.service.MatchService;
 import matches.organizer.service.UserService;
 import matches.organizer.storage.MatchRepository;
+import matches.organizer.storage.PlayerRepository;
 import matches.organizer.storage.UserRepository;
 import matches.organizer.util.JwtUtils;
 import org.junit.jupiter.api.Test;
@@ -20,13 +21,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import javax.servlet.http.Cookie;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -41,8 +39,12 @@ class MatchControllerTest {
 
     @Autowired
     private MockMvc mvc;
-    @Autowired
+    @MockBean
     private MatchRepository matchRepository;
+
+    @MockBean
+    private PlayerRepository playerRepository;
+
     @MockBean
     private UserRepository userRepository;
 
@@ -50,8 +52,6 @@ class MatchControllerTest {
     private JwtUtils jwtUtils;
     @Test
     void matchesRetrieved() throws Exception {
-        sanitize();
-
         User user = createUser();
         Match match = MatchService.createRandomMatch();
         Match match2 = MatchService.createRandomMatch();
@@ -61,13 +61,9 @@ class MatchControllerTest {
             match2.addPlayer(user);
         }
 
-        matchRepository.save(match);
-        matchRepository.save(match2);
+        var matches = List.of(match,match2);
 
-        ArrayList<Match> matches = new ArrayList<>();
-
-        matches.add(match);
-        matches.add(match2);
+        when(matchRepository.findAll()).thenReturn(matches);
 
         this.mvc.perform(get("/matches")
                         .cookie(new Cookie("token",jwtUtils.generateJwt(user)))
@@ -75,7 +71,7 @@ class MatchControllerTest {
                 .andExpect(content().json(getMatchesResponse(matches)));
     }
 
-    private String getMatchesResponse(ArrayList<Match> matches) {
+    private String getMatchesResponse(List<Match> matches) {
         JsonObject allMatches = new JsonObject();
         JsonArray matchesArray = new JsonArray();
         matches.forEach(m -> matchesArray.add(JsonParser.parseString(m.toJsonString())));
@@ -85,11 +81,10 @@ class MatchControllerTest {
 
     @Test
     void getMatch() throws Exception {
-        sanitize();
         User user = createUser();
 
         Match match = MatchService.createRandomMatch();
-        matchRepository.save(match);
+        when(matchRepository.findById(any())).thenReturn(Optional.of(match));
 
         this.mvc.perform(get("/matches/" + match.getId())
                         .cookie(new Cookie("token",jwtUtils.generateJwt(user)))
@@ -104,9 +99,6 @@ class MatchControllerTest {
     void matchesCounterRetrieved() throws Exception {
         ///////							Test Empty Counter					///////
         ///////////////////////////////////////////////////////////////////////////
-        sanitize();
-        User user = createUser();
-
         this.mvc.perform(get("/matches/counter").accept(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isOk()).andExpect(content().json("{\"matches\": 0, \"players\": 0}"));
 
@@ -116,21 +108,12 @@ class MatchControllerTest {
 
         // Valid matches: 1, Valid Players: 2
         Match m1 = MatchService.createRandomMatch();
-        m1.addPlayer(user);
-        m1.addPlayer(user);
-
-        // Invalid matches and players (older than 2 hours)
-        LocalDateTime oderDT = LocalDateTime.now(ZoneOffset.UTC).minusHours(2).minusMinutes(1);
-
-        Match m2 = MatchService.createRandomMatch();
-        m2.setCreatedAt(oderDT);
-
-        m1.addPlayer(user);
-        m1.getPlayers().get(0).setConfirmedAt(oderDT);
+        m1.addPlayer(createUser());
+        m1.addPlayer(createUser());
 
         // Test
-        matchRepository.save(m1);
-        matchRepository.save(m2);
+        when(matchRepository.findByCreatedAtAfter(any())).thenReturn(List.of(m1));
+        when(playerRepository.findAll()).thenReturn(m1.getPlayers());
 
         this.mvc.perform(get("/matches/counter").accept(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
@@ -140,16 +123,12 @@ class MatchControllerTest {
     @Test
     void registerNewPlayer() throws Exception {
 
-        sanitize();
-
         User user = createUser();
         when(userRepository.findById(any())).thenReturn(Optional.of(user));
 
         Match match = MatchService.createRandomMatch();
-        matchRepository.save(match);
-        //Este test debe validar que la lista de usuario este vacia
-        assertTrue(matchRepository.findById(match.getId()).orElse(new Match()).getPlayers().isEmpty());
-
+        match.addPlayer(user);
+        when(matchRepository.findById(any())).thenReturn(Optional.of(match));
 
         ResultActions request = this.mvc.perform(
                 post("/matches/" + match.getId() + "/players")
@@ -160,10 +139,6 @@ class MatchControllerTest {
         request.andExpect(status().isOk());
 
         assertFalse(matchRepository.findById(match.getId()).orElse(new Match()).getPlayers().isEmpty());
-    }
-
-    void sanitize() {
-        matchRepository.findAll().clear();
     }
 
     User createUser() {

--- a/backend/src/test/java/matches/organizer/storage/MatchRepositoryTest.java
+++ b/backend/src/test/java/matches/organizer/storage/MatchRepositoryTest.java
@@ -3,6 +3,7 @@ package matches.organizer.storage;
 import matches.organizer.domain.Match;
 import matches.organizer.domain.MatchBuilder;
 import matches.organizer.domain.User;
+import matches.organizer.service.MatchService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,12 +17,14 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 @DataMongoTest
 @ExtendWith(SpringExtension.class)
 @TestInstance(PER_CLASS)
-public class MatchRepositoryTest {
+class MatchRepositoryTest {
 
     @Autowired
     private MatchRepository matchRepository;
@@ -32,6 +35,7 @@ public class MatchRepositoryTest {
     void setUp() {
         anyMatch = buildAMatch();
         anotherMatch = buildAnotherMatch();
+        matchRepository.deleteAll();
     }
 
     @Test
@@ -74,6 +78,31 @@ public class MatchRepositoryTest {
         matchRepository.save(buildAnotherMatch());
         Assertions.assertNull(matchRepository.findById(anotherMatch.getId()).orElse(null));
         Assertions.assertEquals(anyMatch.getId(),matchRepository.findById(anyMatch.getId()).orElse(new Match()).getId());
+    }
+
+    @Test
+    void findLastMatches(){
+        Match m1 = MatchService.createRandomMatch();
+        // Invalid match (older than 2 hours)
+        LocalDateTime oderDT = LocalDateTime.now(ZoneOffset.UTC).minusHours(2).minusMinutes(1);
+
+        Match m2 = MatchService.createRandomMatch();
+        m2.setCreatedAt(oderDT);
+
+        matchRepository.save(m1);
+        matchRepository.save(m2);
+        Assertions.assertEquals(1,matchRepository.findByCreatedAtAfter(LocalDateTime.now(ZoneOffset.UTC).minusHours(2)).size());
+    }
+
+    @Test
+    void addPlayerToMatch(){
+        Match match = MatchService.createRandomMatch();
+        matchRepository.save(match);
+        //Este test debe validar que la lista de usuario este vacia
+        assertTrue(matchRepository.findById(match.getId()).orElse(new Match()).getPlayers().isEmpty());
+        match.addPlayer(new User("User", "User","0303456", "pp@g.com", "Password"));
+        matchRepository.save(match);
+        assertFalse(matchRepository.findById(match.getId()).orElse(new Match()).getPlayers().isEmpty());
     }
 
     private Match buildAMatch() {


### PR DESCRIPTION
Los únicos tests que no estaban funcionando eran los del controller de matches.

Esto era, porque al igual que me pasó en el de users, los test de springboot que permiten probar la capa de modelo vista controlador "mvc" (`@SpringBootTest`) no son muy compatibles con los tests de la capa de datos de mongo (`@DataMongoTest`). Es porque internamente estas anotations al estar juntas, duplican configuraciones que hacen que se levanten beans por duplicado, y que el contexto no funcione.
Entonces la solución para que se levanten los beans de los repositorios de matches podría haber sido agregar la annotation `@DataMongoTest`, pero por lo dicho arriba, no iba a funcionar tampoco, por lo que se decidió optar por mockear el comportamiento de ese repositorio.

Entiendo que iba a pasar lo mismo si se usaban test containers, porque requieren de la misma anotation.

Los test del repositorio que estaban ocultos dentro de los tests del controlador de matches, los puse donde debían ir.