### PR TITLE
93 optimizar estadisticas

### DIFF
--- a/backend/src/main/java/matches/organizer/controller/MatchController.java
+++ b/backend/src/main/java/matches/organizer/controller/MatchController.java
@@ -30,7 +30,6 @@ import java.util.Map;
 public class MatchController {
     private final MatchService matchService;
     private final UserService userService;
-
     private final JwtUtils jwtUtils;
 
     @Autowired

--- a/backend/src/main/java/matches/organizer/domain/Player.java
+++ b/backend/src/main/java/matches/organizer/domain/Player.java
@@ -1,22 +1,17 @@
 package matches.organizer.domain;
 
 import com.google.gson.*;
-import org.springframework.data.mongodb.core.index.Indexed;
-import org.springframework.data.mongodb.core.mapping.Document;
 import java.lang.reflect.Type;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 
-@Document
+
 public class Player {
 
     private final String userId;
     private final String alias;
 
-    @Indexed(name = "indexConfirmedAt", expireAfterSeconds = 60*60*2, partialFilter = "{ clearable : {$exists : true } }" )
     private LocalDateTime confirmedAt;
-
-    private boolean clearable;
 
     public Player(String userId, String alias) {
         this.userId = userId;
@@ -39,12 +34,6 @@ public class Player {
     public void setConfirmedAt(LocalDateTime confirmedAt) {
         this.confirmedAt = confirmedAt;
     }
-
-    public void setClearable(boolean clearable) { this.clearable = clearable; }
-
-    //public String getClearable() {        return clearable;    }
-
-
 
     public String toJsonString() {
         Gson gson = new GsonBuilder()

--- a/backend/src/main/java/matches/organizer/domain/Statistic.java
+++ b/backend/src/main/java/matches/organizer/domain/Statistic.java
@@ -1,0 +1,56 @@
+package matches.organizer.domain;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+
+@Document
+public class Statistic {
+
+    @Id
+    private String id;
+
+    private int statisticType; // 1 - for matches , 2 - for players.
+
+
+    @Indexed(name = "indexConfirmedAt", expireAfterSeconds = 7200)
+    private LocalDateTime confirmedAt;
+
+
+    public Statistic(int statisticType) {
+        this.id = UUID.randomUUID().toString();
+        this.statisticType = statisticType;
+        this.confirmedAt = LocalDateTime.now(ZoneOffset.UTC);
+    }
+
+
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public int getStatisticType() {
+        return statisticType;
+    }
+
+    public void setStatisticType(int statisticType) {
+        this.statisticType = statisticType;
+    }
+
+    public LocalDateTime getConfirmedAt() {
+        return confirmedAt;
+    }
+
+    public void setConfirmedAt(LocalDateTime confirmedAt) {
+        this.confirmedAt = confirmedAt;
+    }
+}

--- a/backend/src/main/java/matches/organizer/dto/CounterDTO.java
+++ b/backend/src/main/java/matches/organizer/dto/CounterDTO.java
@@ -1,19 +1,19 @@
 package matches.organizer.dto;
 
 public class CounterDTO {
-    private final int matches;
-    private final int players;
+    private final Long matches;
+    private final Long players;
 
-    public CounterDTO(int matches, int players) {
+    public CounterDTO(Long matches, Long players) {
         this.matches = matches;
         this.players = players;
     }
 
-    public int getPlayers() {
+    public Long getPlayers() {
         return players;
     }
 
-    public int getMatches() {
+    public Long getMatches() {
         return matches;
     }
 }

--- a/backend/src/main/java/matches/organizer/storage/PlayerRepository.java
+++ b/backend/src/main/java/matches/organizer/storage/PlayerRepository.java
@@ -1,8 +1,0 @@
-package matches.organizer.storage;
-
-import matches.organizer.domain.Player;
-import org.springframework.data.mongodb.repository.MongoRepository;
-
-public interface PlayerRepository extends MongoRepository<Player, String> {
-
-}

--- a/backend/src/main/java/matches/organizer/storage/StatisticRepository.java
+++ b/backend/src/main/java/matches/organizer/storage/StatisticRepository.java
@@ -1,0 +1,12 @@
+package matches.organizer.storage;
+
+import matches.organizer.domain.Statistic;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+
+public interface StatisticRepository extends MongoRepository<Statistic, String> {
+
+    Long countStatisticByStatisticType(int statisticType);
+
+
+}

--- a/backend/src/test/java/matches/organizer/controller/MatchControllerTest.java
+++ b/backend/src/test/java/matches/organizer/controller/MatchControllerTest.java
@@ -8,7 +8,7 @@ import matches.organizer.domain.User;
 import matches.organizer.service.MatchService;
 import matches.organizer.service.UserService;
 import matches.organizer.storage.MatchRepository;
-import matches.organizer.storage.PlayerRepository;
+import matches.organizer.storage.StatisticRepository;
 import matches.organizer.storage.UserRepository;
 import matches.organizer.util.JwtUtils;
 import org.junit.jupiter.api.Test;
@@ -43,7 +43,7 @@ class MatchControllerTest {
     private MatchRepository matchRepository;
 
     @MockBean
-    private PlayerRepository playerRepository;
+    private StatisticRepository statisticRepository;
 
     @MockBean
     private UserRepository userRepository;
@@ -113,7 +113,7 @@ class MatchControllerTest {
 
         // Test
         when(matchRepository.findByCreatedAtAfter(any())).thenReturn(List.of(m1));
-        when(playerRepository.findAll()).thenReturn(m1.getPlayers());
+        when(statisticRepository.countStatisticByStatisticType(1)).thenReturn((long) m1.getPlayers().size());
 
         this.mvc.perform(get("/matches/counter").accept(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())

--- a/backend/src/test/java/matches/organizer/controller/MatchControllerTest.java
+++ b/backend/src/test/java/matches/organizer/controller/MatchControllerTest.java
@@ -112,8 +112,8 @@ class MatchControllerTest {
         m1.addPlayer(createUser());
 
         // Test
-        when(matchRepository.findByCreatedAtAfter(any())).thenReturn(List.of(m1));
-        when(statisticRepository.countStatisticByStatisticType(1)).thenReturn((long) m1.getPlayers().size());
+        when(statisticRepository.countStatisticByStatisticType(1)).thenReturn(1L);
+        when(statisticRepository.countStatisticByStatisticType(2)).thenReturn((long) m1.getPlayers().size());
 
         this.mvc.perform(get("/matches/counter").accept(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())


### PR DESCRIPTION
Elimina el repo de Players y crea un repo de Statistics. 

Cada vez que se crea un match inserta una estadística de tipo 1.
Cada vez que se agrega un player a un match inserta una estadística de tipo 2.

Cada estadística independientemente del tipo tiene auto-expiración luego de 2 horas. Se crea un query de tipo count por tipo de estadística y se consulta desde el endpoint correspondiente.